### PR TITLE
feat: apply to git config when selecting a registered user

### DIFF
--- a/cmd/user.go
+++ b/cmd/user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"os"
 )
 
 // gitAccount represents the gitAccount command
@@ -133,6 +134,11 @@ func selectDeletingUser(userSuggestion []complete.Suggestion) string {
 }
 
 func selectFlag(user User) string {
+	gitLocalConfigFile, err := os.Stat("./.git/config")
+	if os.IsNotExist(err) || gitLocalConfigFile.IsDir() {
+		return "--global"
+	}
+
 	suggestions := []complete.Suggestion{
 		{Name: "--global", Desc: "set up global "},
 		{Name: "--local", Desc: "set up local "},


### PR DESCRIPTION
- 등록된 사용자 계정을 Suggestion 리스트에 추가
- Suggestion 선택시 git config 명령어 실행해서 깃 설정 (우선 global 설정은 처리하지 않음) 
- 등록된 사용자 계정을 'add user', 'remove user', 'reset' 선택지하고 같은 depth에 둠
![image](https://user-images.githubusercontent.com/16451031/129511556-f3872b8c-2e97-4e8e-ad75-91389060c2d3.png)

- global / local 옵션 플래그 선택하는 suggestion 추가
   - 현재 디렉토리 하위에 `.git/config` 파일없으면 디폴트로 global 플래그 적용 